### PR TITLE
Implementing --untranslated correctly and allowing multiple .po files

### DIFF
--- a/autotranslate/management/commands/translate_messages.py
+++ b/autotranslate/management/commands/translate_messages.py
@@ -7,7 +7,7 @@ import polib
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from autotranslate.utils import translate_strings
+from autotranslate.utils import get_translator
 
 logger = logging.getLogger(__name__)
 
@@ -87,16 +87,18 @@ class Command(BaseCommand):
 
         po = polib.pofile(os.path.join(root, file_name))
         strings = self.get_strings_to_translate(po)
+        print "Translating", file_name, "to", target_language, "; Num Strings:", len(strings)
         # translate the strings,
         # all the translated strings are returned
         # in the same order on the same index
         # viz. [a, b] -> [trans_a, trans_b]
-        translated_strings = translate_strings(strings, target_language, 'en', False)
+        tl = get_translator()
+        translated_strings = tl.translate_strings(strings, target_language, 'en', False)
         self.update_translations(po, translated_strings)
         po.save()
 
     def need_translate(self, entry):
-        return not self.skip_translated or not entry.translated() or not entry.obsolete
+        return not entry.obsolete and (not (self.skip_translated and entry.translated()))
 
     def get_strings_to_translate(self, po):
         """Return list of string to translate from po file.

--- a/autotranslate/services.py
+++ b/autotranslate/services.py
@@ -78,7 +78,9 @@ class GoogleAPITranslatorService(BaseTranslatorService):
         assert isinstance(strings, collections.MutableSequence), \
             '`strings` should be a sequence containing string_types'
         assert not optimized, 'optimized=True is not supported in `GoogleAPITranslatorService`'
-        if len(strings) <= self.max_segments:
+        if len(strings) == 0:
+            return []
+        elif len(strings) <= self.max_segments:
             setattr(self, 'translated_strings', getattr(self, 'translated_strings', []))
             response = self.service.translations() \
                 .list(source=source_language, target=target_language, q=strings).execute()

--- a/autotranslate/utils.py
+++ b/autotranslate/utils.py
@@ -32,10 +32,11 @@ def import_from_string(val, setting_name):
         raise ImportError('Could not import {} for API setting {}. {}: {}.'
                           .format(val, setting_name, e.__class__.__name__, e))
 
-
-TranslatorService = getattr(settings, 'AUTOTRANSLATE_TRANSLATOR_SERVICE',
-                            'autotranslate.services.GoSlateTranslatorService')
-translator = perform_import(TranslatorService, 'AUTOTRANSLATE_TRANSLATOR_SERVICE')()
-
-translate_string = translator.translate_string
-translate_strings = translator.translate_strings
+def get_translator():
+    """
+    Returns the default translator.
+    """
+    TranslatorService = getattr(settings, 'AUTOTRANSLATE_TRANSLATOR_SERVICE',
+                                'autotranslate.services.GoSlateTranslatorService')
+    translator = perform_import(TranslatorService, 'AUTOTRANSLATE_TRANSLATOR_SERVICE')()
+    return translator


### PR DESCRIPTION
This pull request fixes two bugs I found:

- Supporting multiple .po files per language: This can arise when you generate a catalog for the javascript strings. This creates a django.po and a djangojs.po per language. Sharing the translator object across files makes one of them have wrong translation. 

- --untranslated flag wasn't really working. The boolean condition used to check if entry needs to translated was `not self.skip_translated or not entry.translated() or not entry.obsolete`, the right one would be `not entry.obsolete and (not (self.skip_translated and entry.translated()))`