### PR TITLE
Fixed error with pip 10.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@ import uuid
 
 from distutils.core import setup
 from setuptools import find_packages
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
pip > 10.x does not have parse_requirements in pip.req module.
from pip._internal.req import parse_requirements is the solution.
Without this, build will fail.