### PR TITLE
Fix bug on parse_requirements using pip==20.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 install_requirements = parse_requirements(os.path.join(PROJECT_ROOT, 'requirements.txt'), session=uuid.uuid1())
 
 # e.g. ['django', 'google-api-python-client']
-requirements = [str(ir.req) for ir in install_requirements]
+requirements = [getattr(ir, 'requirement', str(getattr(ir, 'req', None))) for ir in install_requirements]
 
 setup(
     name='django-autotranslate',


### PR DESCRIPTION
Fixes error when calling the parse_requirements method when installing using pip==20.1

Refs #25 