### PR TITLE
Add argument --source-language to override the hardcoded default "en"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Options:
 - ``-f, --set-fuzzy``: Set the 'fuzzy' flag on autotranslated entries
 - ``-l, --locale 'locale'``: Only translate the specified locales
 - ``-u, --untranslated``: Only translate the untranslated messages
+- ``-s, --source-language``: Override the default source language (en) used for translation
 
 ```bash
     python manage.py translate_messages -l 'de' -l 'es'

--- a/autotranslate/management/commands/translate_messages.py
+++ b/autotranslate/management/commands/translate_messages.py
@@ -31,6 +31,8 @@ class Command(BaseCommand):
                     help='autotranslate the fuzzy and empty messages only.'),
         make_option('--set-fuzzy', '-f', default=False, dest='set_fuzzy', action='store_true',
                     help='set the fuzzy flag on autotranslated messages.'),
+        make_option('--source-language', '-s', default='en', dest='source_language', action='store',
+                    help='override the default source language (en) used for translation.'),
     )
 
     def add_arguments(self, parser):
@@ -45,11 +47,14 @@ class Command(BaseCommand):
                             help='autotranslate the fuzzy and empty messages only.')
         parser.add_argument('--set-fuzzy', '-f', default=False, dest='set_fuzzy', action='store_true',
                             help='set the fuzzy flag on autotranslated messages.')
+        parser.add_argument('--source-language', '-s', default='en', dest='source_language', action='store',
+                            help='override the default source language (en) used for translation.')
 
     def set_options(self, **options):
         self.locale = options['locale']
         self.skip_translated = options['skip_translated']
         self.set_fuzzy = options['set_fuzzy']
+        self.source_language = options['source_language']
 
     def handle(self, *args, **options):
         self.set_options(**options)
@@ -93,7 +98,7 @@ class Command(BaseCommand):
         # in the same order on the same index
         # viz. [a, b] -> [trans_a, trans_b]
         tl = get_translator()
-        translated_strings = tl.translate_strings(strings, target_language, 'en', False)
+        translated_strings = tl.translate_strings(strings, target_language, self.source_language, False)
         self.update_translations(po, translated_strings)
         po.save()
 


### PR DESCRIPTION
This is a minor change to make the hardcoded source_language configurable.
Use case: If a Django applications translatable strings have been written in a language other than English, the management command fails when translating to English with:
`googleapiclient.errors.HttpError: <HttpError 400 when requesting https://translation.googleapis.com/language/translate/v2?source=en&target=en&q=...&key=...&alt=json returned "Bad language pair: en|en". Details: "[{'message': 'Bad language pair: en|en', 'domain': 'global', 'reason': 'badRequest'}]">`